### PR TITLE
Change dependency and build scripts to work on OS X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-if [ -d "dmd2" ]; then
-    DMD="./dmd2/linux/bin64/dmd";
-else
-    DMD="dmd"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    BIN="linux/bin64"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    BIN="osx/bin"
 fi
+
+DMD="./dmd2/$BIN/dmd"
 
 # debug build
 $DMD -gc -debug -J. *.d -ofpsi

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,11 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     BIN="osx/bin"
 fi
 
-DMD="./dmd2/$BIN/dmd"
+if [[ -d "dmd2" ]]; then
+    DMD="./dmd2/$BIN/dmd"
+else
+    DMD="dmd"
+fi
 
 # debug build
 $DMD -gc -debug -J. *.d -ofpsi

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,11 +1,23 @@
 #!/bin/bash
 if [ ! -d dmd2 ]; then
-    SUM1="c6dc5df0eeac35d37db167b9a80eb08e  dmd.2.072.2.linux.zip"
-    wget http://downloads.dlang.org/releases/2.x/2.072.2/dmd.2.072.2.linux.zip
-    SUM2=`md5sum dmd.2.072.2.linux.zip`
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        FILE="dmd.2.072.2.linux.zip"
+        SUM1="c6dc5df0eeac35d37db167b9a80eb08e  $FILE"
+	ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
+	MD5="md5sum"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        FILE="dmd.2.072.2.osx.zip"
+	SUM1="MD5 (dmd.2.072.2.osx.zip) = 0844f3218043a21dcc7a3fc76605af5d"
+	ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
+	MD5="md5"
+    fi
+
+    wget $ZIPLINK
+    SUM2=`$MD5 $FILE`
+
     if [[ $SUM1 != $SUM2 ]]; then
 	echo "ERROR: md5 sum mismatch"
     else
-	unzip dmd.2.072.2.linux.zip
+	unzip $FILE
     fi
 fi

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ ! -d dmd2 ]; then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
         FILE="dmd.2.072.2.linux.zip"
         SUM1="c6dc5df0eeac35d37db167b9a80eb08e  $FILE"
 	ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -3,13 +3,13 @@ if [ ! -d dmd2 ]; then
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
         FILE="dmd.2.072.2.linux.zip"
         SUM1="c6dc5df0eeac35d37db167b9a80eb08e  $FILE"
-	ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
-	MD5="md5sum"
+        ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
+        MD5="md5sum"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         FILE="dmd.2.072.2.osx.zip"
-	SUM1="MD5 (dmd.2.072.2.osx.zip) = 0844f3218043a21dcc7a3fc76605af5d"
-	ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
-	MD5="md5"
+        SUM1="MD5 ($FILE) = 0844f3218043a21dcc7a3fc76605af5d"
+        ZIPLINK="http://downloads.dlang.org/releases/2.x/2.072.2/$FILE"
+        MD5="md5"
     fi
 
     wget $ZIPLINK


### PR DESCRIPTION
I tested the changes on OSX Sierra (10.12.3) and works fine. It will be great if
someone can verify that I didn't break anything on linux side.