### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM dlanguage/dmd
+LABEL "Version"="1.0"
+
+COPY . /opt/psi
+
+RUN apt -qq update && apt -qq install -y wget unzip
+RUN cd /opt/psi && ./dependencies.sh && ./build.sh && mkdir bin && mv psi ./bin
+
+RUN echo "export PATH=$PATH:/opt/psi/bin" >> /root/.bashrc
+
+WORKDIR /root
+
+ENTRYPOINT ["bash"]
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ PSI is written in the D programming language. D compilers are available at http:
 ./build.sh creates a debug build.
 ./build-release creates a release build.
 
+### Using Docker
+
+Build with `docker build . -t psi`, then launch the container with `docker run -it psi`.
+
+You can eventually share files between your filesystem and the container using the `-v` option.
+
 ### Other platforms
 
 The build instructions given here are for GNU/Linux. PSI also works on other platforms.


### PR DESCRIPTION
To avoid installing all the dependencies I thought it would be a good idea to create a self-contained docker image.
Please let me know if the small paragraph on the readme is clear enough.

Thanks